### PR TITLE
Add stats screen with reverse geocoding

### DIFF
--- a/Run_Map/ContentView.swift
+++ b/Run_Map/ContentView.swift
@@ -253,6 +253,7 @@ struct ContentView: View {
     @State private var liveCoordinates: [CLLocationCoordinate2D] = []
     @State private var trackingTimer: Timer?
     @State private var showControls = false
+    @State private var showStats = false
 
     // Stats banner state
     @AppStorage("lastRunCount") private var lastRunCount = 0
@@ -368,6 +369,12 @@ struct ContentView: View {
                                     (mapType == .standard ? MKMapType.satellite : MKMapType.standard).rawValue
                                 )
                             }
+
+                        // Stats button
+                        circleButton(icon: "chart.bar")
+                            .onTapGesture {
+                                showStats = true
+                            }
                     }
 
                     // Main FAB that toggles the stack
@@ -431,6 +438,9 @@ struct ContentView: View {
                 loadDemoWorkouts()
                 showNoWorkouts = false
             }
+        }
+        .sheet(isPresented: $showStats) {
+            StatsView(routes: viewModel.displayedRoutes)
         }
         .alert(summaryMessage ?? "", isPresented: $showSummaryAlert) {
             Button("OK", role: .cancel) { }

--- a/Run_Map/StatsView.swift
+++ b/Run_Map/StatsView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import CoreLocation
+
+struct StatsView: View {
+    var routes: [Route]
+    @Environment(\.dismiss) private var dismiss
+    @State private var totalKm: Double = 0
+    @State private var countryTotals: [(String, Double)] = []
+    @State private var cityTotals: [(String, Double)] = []
+    @State private var loading = true
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("You ran \(Int(totalKm))km in total.")
+                        .font(.headline)
+                        .padding(.bottom, 8)
+                    if !countryTotals.isEmpty {
+                        Text("Your top countries were:").font(.subheadline)
+                        ForEach(Array(countryTotals.prefix(3).enumerated()), id: \.offset) { idx, entry in
+                            Text("\(idx + 1)) \(entry.element.0) \(Int(entry.element.1))km")
+                        }
+                        .padding(.bottom, 8)
+                    }
+                    if !cityTotals.isEmpty {
+                        Text("Your top cities were:").font(.subheadline)
+                        ForEach(Array(cityTotals.prefix(3).enumerated()), id: \.offset) { idx, entry in
+                            Text("\(idx + 1)) \(entry.element.0) \(Int(entry.element.1))km")
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+            }
+            .navigationTitle("Stats")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+        .onAppear(perform: computeStats)
+    }
+
+    private func computeStats() {
+        totalKm = routes.map(\.distanceKm).reduce(0, +)
+        let geocoder = CLGeocoder()
+        var countryDict: [String: Double] = [:]
+        var cityDict: [String: Double] = [:]
+        let group = DispatchGroup()
+
+        for route in routes {
+            guard let first = route.coordinates.first else { continue }
+            group.enter()
+            let location = CLLocation(latitude: first.latitude, longitude: first.longitude)
+            geocoder.reverseGeocodeLocation(location) { placemarks, _ in
+                if let placemark = placemarks?.first {
+                    if let country = placemark.country {
+                        countryDict[country, default: 0] += route.distanceKm
+                    }
+                    if let city = placemark.locality {
+                        cityDict[city, default: 0] += route.distanceKm
+                    }
+                }
+                group.leave()
+            }
+        }
+
+        group.notify(queue: .main) {
+            countryTotals = countryDict.sorted { $0.value > $1.value }
+            cityTotals = cityDict.sorted { $0.value > $1.value }
+            loading = false
+        }
+    }
+}
+
+struct StatsView_Previews: PreviewProvider {
+    static var previews: some View {
+        StatsView(routes: [])
+    }
+}


### PR DESCRIPTION
## Summary
- add new `StatsView` that aggregates routes by country and city using `CLGeocoder`
- expose a button from `ContentView` to open the stats screen

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6855731a5b2083298f9aa273c1178fa3